### PR TITLE
插入新行时确保光标在行尾

### DIFF
--- a/mind-wave.el
+++ b/mind-wave.el
@@ -328,6 +328,7 @@ Then Mind-Wave will start by gdb, please send new issue with `*mind-wave*' buffe
 
 (defun mind-wave-chat-ask-send-buffer ()
   (interactive)
+  (goto-char (line-end-position))
   (insert "\n")
   (message "Wait ChatGPT...")
   (mind-wave-call-async "chat_ask"


### PR DESCRIPTION
有时候在行中调用mind-wave-chat-ask-send-buffer时，插入的\n会把行截断，所以想能不能先移动到行尾，不知道你的意见如何