### PR TITLE
Slice the buffer content for the api token limit

### DIFF
--- a/mind-wave.el
+++ b/mind-wave.el
@@ -79,7 +79,7 @@
 (require 'mind-wave-epc)
 (require 'markdown-mode)
 
-(when (version< emacs-version "30")
+(when (version< emacs-version "28.1")
   (defun file-name-concat (&rest parts)
     (cl-reduce (lambda (a b) (expand-file-name b a)) parts)))
 

--- a/mind-wave.el
+++ b/mind-wave.el
@@ -360,7 +360,7 @@ Then Mind-Wave will start by gdb, please send new issue with `*mind-wave*' buffe
 (add-to-list 'auto-mode-alist '("\\.chat$" . mind-wave-chat-mode))
 
 (defun mind-wave-get-buffer-string ()
-  (buffer-substring-no-properties (point-min) (point-max)))
+  (buffer-substring-no-properties (max (point-min) (- (point-max) 4096))  (point-max)))
 
 (defun mind-wave-chat-ask-with-message (prompt)
   (save-excursion


### PR DESCRIPTION
about this issue https://github.com/manateelazycat/mind-wave/issues/25
I temply slice the buffer string. I think the better way is select by the ask and answer session. 