### PR TITLE
Fix: the file-name-concat is introduced before 28.1, this redefine wi…

### DIFF
--- a/mind-wave.el
+++ b/mind-wave.el
@@ -79,7 +79,7 @@
 (require 'mind-wave-epc)
 (require 'markdown-mode)
 
-(when (version< emacs-version "30")
+(when (version< emacs-version "29")
   (defun file-name-concat (&rest parts)
     (cl-reduce (lambda (a b) (expand-file-name b a)) parts)))
 


### PR DESCRIPTION
It cause tramp stack overflow on macos emacs29