### PR TITLE
fix azure openai model openai.error.InvalidRequestError, by change parameter `model` to `engine` when openai.api_type == 'azure'

### DIFF
--- a/mind_wave.py
+++ b/mind_wave.py
@@ -112,9 +112,14 @@ class MindWave:
 
     @catch_exception
     def send_completion_request(self, messages, model="gpt-3.5-turbo"):
-        response = openai.ChatCompletion.create(
-            model = model,
-            messages = messages)
+        if openai.api_type == 'azure':
+            response = openai.ChatCompletion.create(
+                engine = model,
+                messages = messages)
+        else:
+            response = openai.ChatCompletion.create(
+                model = model,
+                messages = messages)
 
         result = ''
         for choice in response.choices:
@@ -124,11 +129,18 @@ class MindWave:
 
     @catch_exception
     def send_stream_request(self, messages, callback, model="gpt-3.5-turbo"):
-        response = openai.ChatCompletion.create(
-            model = model,
-            messages = messages,
-            temperature=0,
-            stream=True)
+        if openai.api_type == 'azure':
+            response = openai.ChatCompletion.create(
+                engine = model,
+                messages = messages,
+                temperature=0,
+                stream=True)
+        else:
+            response = openai.ChatCompletion.create(
+                model = model,
+                messages = messages,
+                temperature=0,
+                stream=True)
 
         for chunk in response:
             (result_type, result_content) = self.get_chunk_result(chunk)
@@ -339,11 +351,18 @@ class MindWave:
                     {"role": "user", "content": f"{prompt}： \n{text}"}]
 
         try:
-            response = openai.ChatCompletion.create(
-                model = "gpt-3.5-turbo",
-                messages = messages,
-                temperature=0,
-                stream=True)
+            if openai.api_type == 'azure':
+                response = openai.ChatCompletion.create(
+                    engine = "gpt-3.5-turbo",
+                    messages = messages,
+                    temperature=0,
+                    stream=True)
+            else:
+                response = openai.ChatCompletion.create(
+                    model = "gpt-3.5-turbo",
+                    messages = messages,
+                    temperature=0,
+                    stream=True)
 
             for chunk in response:
                 (result_type, result_content) = self.get_chunk_result(chunk)


### PR DESCRIPTION
The azure openai model using `engine` parameter to set the model name. This  PR will fix errors as following:

``` python

[Mind-Wave] Traceback (most recent call last):
  File "/home/sawyer/.emacs.d.clean/straight/build/mind-wave/mind_wave.py", line 35, in wrapper
    return func(*args, **kwargs)
  File "/home/sawyer/.emacs.d.clean/straight/build/mind-wave/mind_wave.py", line 128, in send_stream_request
    temperature=0,
  File "/home/sawyer/.local/lib/python3.10/site-packages/openai/api_resources/chat_completion.py", line 25, in create
    return super().create(*args, **kwargs)
  File "/home/sawyer/.local/lib/python3.10/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 149, in create
    ) = cls.__prepare_create_request(
  File "/home/sawyer/.local/lib/python3.10/site-packages/openai/api_resources/abstract/engine_api_resource.py", line 83, in __prepare_create_request
    raise error.InvalidRequestError(
openai.error.InvalidRequestError: Must provide an ’engine’ or ’deployment_id’ parameter to create a <class ’openai.api_resources.chat_completion.ChatCompletion’>

```